### PR TITLE
Update .gitignore for venv, fix PEP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,8 @@ pip-wheel-metadata/
 
 # Mac OSX
 .DS_Store
+
+local-files
+input-files
+output-files
+38venv

--- a/corazon_runner/README.md
+++ b/corazon_runner/README.md
@@ -1,0 +1,11 @@
+# Running Corazon Runner
+
+This runner application encapsulates corazon with a commandline interface. The interface boils down manual steps into
+easily automatable procedures which can be initialized by bash scripts, or other automations.
+
+### How to setup and run the first set of calculations
+
+```
+PYTHONPATH='.' python corazon_runner/factory.py -i input-files/first-dataset -o output-files/first-dataset -m sync-data
+PYTHONPATH='.' python corazon_runner/factory.py -i input-files/first-dataset -o output-files/first-dataset -m run-calc
+```

--- a/corazon_runner/constants.py
+++ b/corazon_runner/constants.py
@@ -1,0 +1,4 @@
+import os
+
+LOCAL_DATA_PATH = os.path.join(os.getcwd(), 'local-data')
+DATA_HOST = os.environ.get('DATA_HOST', None)

--- a/corazon_runner/datatypes.py
+++ b/corazon_runner/datatypes.py
@@ -1,0 +1,18 @@
+import enum
+import typing
+
+
+class Mode(enum.Enum):
+    SyncData = 'sync-data'
+    RunCalculation = 'run-calc'
+    RunConcurrently = 'run-multi-calc'
+
+
+class TESSLightCurveFile(typing.NamedTuple):
+    sector: str
+    tic: int
+    rel_filename: str
+    rel_path: str
+    local_dir: str
+    option: str
+    output_dir: str

--- a/corazon_runner/factory.py
+++ b/corazon_runner/factory.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import argparse
+
+from corazon_runner.constants import DATA_HOST
+from corazon_runner.datatypes import Mode
+from corazon_runner.utils import test_against_tess_data, sync_data, test_against_tess_data_multi
+
+
+def capture_options() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-o', '--data-output', required=True,
+                        help="Where to store the output data")
+    parser.add_argument('-i', '--data-input', required=True,
+                        help="Where to find input data")
+    parser.add_argument('-m', '--mode', type=Mode, required=True)
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    options = capture_options()
+    if options.mode is Mode.RunCalculation:
+        test_against_tess_data(options.data_input, options.data_output)
+
+    elif options.mode is Mode.SyncData:
+        sync_data(DATA_HOST, options.data_input)
+
+    elif options.mode is Mode.RunConcurrently:
+        test_against_tess_data_multi(options.data_input, options.data_output)
+
+    else:
+        raise NotImplementedError(options.mode)
+
+
+if __name__ == '__main__':
+    main()

--- a/corazon_runner/utils.py
+++ b/corazon_runner/utils.py
@@ -1,0 +1,124 @@
+import glob
+import os
+import subprocess
+import time
+import types
+
+from corazon_runner.constants import LOCAL_DATA_PATH
+from corazon_runner.datatypes import TESSLightCurveFile
+
+
+def locate_and_resolve_tess_datums(input_dir: str) -> types.GeneratorType:
+    for filepath in glob.glob(f'{input_dir}/*.txt'):
+        filename = os.path.basename(filepath)
+        print(f'Loading File: {filename}')
+        with open(filepath, 'rb') as stream:
+            lines = stream.read().decode('utf-8').split('\n')
+
+        filepath_name = '-'.join(os.path.basename(filepath).rsplit('.', 1)[0].rsplit('_', 3)[1:])
+        for line in lines:
+            if line in ['']:
+                continue
+
+            rel_path = os.path.join(LOCAL_DATA_PATH, line.strip('/'))
+            if not os.path.exists(rel_path):
+                continue
+
+            rel_filename = os.path.basename(line)
+            if rel_filename.startswith('hlsp_tess-spoc'):
+                hunk, sector = rel_filename.rsplit('-', 1)
+                sector, hunk = sector.split('_', 1)
+                sector = int(sector.strip('s'))
+                tic, hunk = rel_filename.rsplit('-', 1)
+                hunk, tic = tic.rsplit('_', 1)
+                tic = int(tic)
+                local_dir = os.path.dirname(rel_path)
+                output_dir = os.path.join('spoc', filepath_name)
+                yield TESSLightCurveFile(sector, tic, rel_filename, rel_path, local_dir, 'tess-spoc', output_dir)
+
+            elif rel_filename.startswith('hlsp_qlp_tess'):
+                sector, hunk = rel_filename.rsplit('-', 1)
+                hunk, sector = sector.rsplit('_', 1)
+                sector = int(sector.strip('s'))
+                hunk, tic = rel_filename.rsplit('-', 1)
+                tic, hunk = tic.split('_', 1)
+                tic = int(tic)
+                local_dir = os.path.dirname(rel_path)
+                output_dir = os.path.join('qlp', filepath_name)
+                yield TESSLightCurveFile(sector, tic, rel_filename, rel_path, local_dir, 'qlp', output_dir)
+
+            else:
+                raise NotImplementedError(line)
+
+def test_against_tess_data(input_dir: str, output_dir: str) -> None:
+    import os
+    import shutil
+    import tempfile
+
+    from corazon import run_pipeline
+
+    from tess_stars2px import tess_stars2px_function_entry
+
+    entries = []
+    for entry in locate_and_resolve_tess_datums(input_dir):
+        entries.append(entry)
+
+    if os.path.exists(output_dir):
+        raise IOError(f'Output DIR Exists: {output_dir}')
+
+    os.makedirs(output_dir)
+
+    # import pdb; pdb.set_trace()
+    print(f'Light curves found: {len(entries)}')
+    print(f'Output Directory: {output_dir}')
+    for idx, entry in enumerate(entries):
+        if idx % 100 == 0:
+            print(f'Chunk: {idx}')
+
+        tic_folder = os.path.join(output_dir, entry.output_dir, str(entry.tic))
+        if not os.path.exists(tic_folder):
+            os.makedirs(tic_folder)
+
+        # tic_folder = os.path.join(output_dir, str(entry.tic))
+        run_pipeline.run_write_one(entry.tic, entry.sector, tic_folder, entry.option, entry.local_dir)
+
+
+def run_command(cmd: str) -> None:
+    proc = subprocess.Popen(cmd, shell=True)
+    while proc.poll() is None:
+        time.sleep(.1)
+        continue
+
+    if proc.poll() in [23]:
+        pass
+
+    elif proc.poll() > 0:
+        raise NotImplementedError(f'Program Error: {proc.poll()}')
+
+
+def sync_data(host: str, input_dir: str) -> None:
+    for filepath in glob.glob(f'{input_dir}/*.txt'):
+        cmd = [f'rsync -avp --files-from {filepath} {host}: {LOCAL_DATA_PATH}']
+        import pdb; pdb.set_trace()
+        run_command(cmd)
+
+def test_against_tess_data_multi(input_dir: str, output_dir: str) -> None:
+    import os
+    import shutil
+    import tempfile
+
+    from corazon import run_pipeline
+
+    from tess_stars2px import tess_stars2px_function_entry
+
+    entries = []
+    for entry in locate_and_resolve_tess_datums(input_dir):
+        entries.append(entry)
+
+    if os.path.exists(output_dir):
+        raise IOError('Output DIR Exists: {output_dir}')
+
+    os.makedirs(output_dir)
+
+    print(f'Light curves found: {len(entries)}')
+    print(f'Output Directory: {output_dir}')


### PR DESCRIPTION
The original focus of this PR was to add additional files to `.gitignore`. Then I started fixing the different build steps so that we have passing builds.

Along the way, by fixing the `flake8` errors. I became more familiar with the code and how it runs. I really like reading the code, I'm learning a lot!

To run all checks locally
```
$ pip install tox
$ tox
```

To run `flake8` locally
```
$ pip install tox
$ tox -e codestyle
```

To run `bandit` locally
```
$ pip install tox
$ tox -e securityaudit
```