### PR TITLE
ENH: Enable auto PyPI publish

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -13,11 +13,28 @@ on:
       - master
 
 jobs:
+  cancel_ci:
+    name: Mandatory checks before CI
+    runs-on: ubuntu-latest
+    outputs:
+      run_next: ${{ steps.skip_ci_step.outputs.run_next }}
+    steps:
+    - name: Check skip CI
+      uses: OpenAstronomy/action-skip-ci@main
+      id: skip_ci_step
+      with:
+        NO_FAIL: true
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # The rest only run if above are done
+
   # Github Actions supports ubuntu, windows, and macos virtual environments:
   # https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
   ci_tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    needs: cancel_ci
+    if: needs.cancel_ci.outputs.run_next == 'true'
     strategy:
       matrix:
         include:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    if: github.repository == 'spacetelescope/corazon'
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install python-build and twine
+      run: python -m pip install build "twine>=3.3"
+
+    - name: Build package
+      run: python -m build --sdist --wheel .
+
+    - name: List result
+      run: ls -l dist
+
+    - name: Check dist
+      run: python -m twine check --strict dist/*
+
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
ENH: Enable auto PyPI publish (precursor to #2)

TST: Enable skipping CI

**TODO**

- [x] Remove `pull_request` from `publish.yml` after successfully tested in this PR.