### PR TITLE
remove usages of deprecated `codecov` package

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,6 @@ description =
 # The following provides some specific pinnings for key packages
 deps =
 
-    cov: codecov
     cov: coverage
     cov: pytest-cov
 


### PR DESCRIPTION
the `codecov` package is now deprecated and has been yanked from PyPI